### PR TITLE
Update Hashicorp Product versions & HAProxy available as on 2-25-2018

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", guest: 4646, host: 4646
 
   config.vm.provision "shell", path: "files/base.sh"
   config.vm.provision "shell", path: "files/consul.sh"

--- a/files/base.sh
+++ b/files/base.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#Set DEBIAN_FRONTEND as noninteractive. This is required to avoid the error
+# dpkg-preconfigure: unable to re-open stdin: No such file or directory
+export DEBIAN_FRONTEND=noninteractive
+
 apt-get update
 
 echo "Installing unzip"
@@ -8,4 +12,5 @@ apt-get install -y -q unzip
 echo "Installing supervisor"
 apt-get install -y -q supervisor
 apt-get install -y virtualenv python-pip
+pip install --upgrade pip
 pip install -r /vagrant/requirements.txt

--- a/files/consul-template.sh
+++ b/files/consul-template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONSUL_TEMPLATE_VERSION=0.19.2
+CONSUL_TEMPLATE_VERSION=0.19.4
 CONSUL_TEMPLATE_ARCH=linux_amd64
 
 echo "Getting consul-template binary"

--- a/files/consul.sh
+++ b/files/consul.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONSUL_VERSION=0.9.2
+CONSUL_VERSION=1.0.6
 CONSUL_ARCH=linux_amd64
 
 echo "Getting consul binary"

--- a/files/dnsmasq.sh
+++ b/files/dnsmasq.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 echo "Installing dnsmasq"
 apt-get install -y -q dnsmasq
 cp /vagrant/dnsmasq.conf /etc/dnsmasq.conf

--- a/files/haproxy.sh
+++ b/files/haproxy.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-apt-get install -y haproxy
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get install -y software-properties-common
+add-apt-repository ppa:vbernat/haproxy-1.8
+apt-get update
+apt-get install -y haproxy=1.8.\*

--- a/files/hashi-ui.sh
+++ b/files/hashi-ui.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HASHI_UI_VERSION=0.18.0
+HASHI_UI_VERSION=0.23.0
 HASHI_UI_ARCH=linux-amd64
 
 echo "Getting hashi-ui binary"

--- a/files/nomad.sh
+++ b/files/nomad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NOMAD_VERSION=0.6.2
+NOMAD_VERSION=0.7.1
 NOMAD_ARCH=linux_amd64
 
 echo "Getting nomad binary"

--- a/files/vault.sh
+++ b/files/vault.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VAULT_VERSION=0.8.1
+VAULT_VERSION=0.9.4
 VAULT_ARCH=linux_amd64
 
 echo "Getting vault binary"
@@ -22,10 +22,10 @@ sleep 5
 
 export VAULT_ADDR=http://127.0.0.1:8200
 TOKEN=$(grep 'Root Token' /var/log/vault/out | tail -n1 | awk '{print $3}')
-echo $TOKEN | vault auth -
-vault token-create -id="1e9e1f5a-3c23-a5d2-d308-ed2c3dd541c4"
-vault auth 1e9e1f5a-3c23-a5d2-d308-ed2c3dd541c4
-vault policy-write secret /vagrant/acl.hcl
+echo $TOKEN | vault login -
+vault token create -id="1e9e1f5a-3c23-a5d2-d308-ed2c3dd541c4"
+vault login 1e9e1f5a-3c23-a5d2-d308-ed2c3dd541c4
+vault policy write secret /vagrant/acl.hcl
 vault write /auth/token/roles/nomad-cluster @/vagrant/nomad-cluster-role.json
-vault policy-write nomad-server /vagrant/nomad-server-policy.hcl
+vault policy write nomad-server /vagrant/nomad-server-policy.hcl
 echo -n "12345" | vault write secret/password value=-


### PR DESCRIPTION
Tested and working locally

Vagrant version - 2.0.2